### PR TITLE
frontend vars

### DIFF
--- a/k8s/openstad/templates/frontend/deployment.yaml
+++ b/k8s/openstad/templates/frontend/deployment.yaml
@@ -43,7 +43,7 @@ spec:
             - name: NODE_ENV
               value: 'production'
             - name: APOS_BUNDLE
-              value: 1
+              value: 'assets'
             - name: GOOGLE_MAPS_API_KEY
               value: "{{ .Values.frontend.googleMapsApiKey }}"
             - name: COOKIE_MAX_AGE

--- a/k8s/openstad/templates/frontend/deployment.yaml
+++ b/k8s/openstad/templates/frontend/deployment.yaml
@@ -40,6 +40,10 @@ spec:
               value: 'ON'
             - name: APOS_WORKFLOW
               value: 'ON'
+            - name: NODE_ENV
+              value: 'production'
+            - name: APOS_BUNDLE
+              value: 1
             - name: GOOGLE_MAPS_API_KEY
               value: "{{ .Values.frontend.googleMapsApiKey }}"
             - name: COOKIE_MAX_AGE


### PR DESCRIPTION
To use the assets generation correctly APOS_BUNDLE and NODE_ENV must be set to assets and production. (See generation assets in frontend)
