### PR TITLE
fix(helm): Remove hardcoded hostname from nc command and use env variable instead

### DIFF
--- a/k8s/openstad/templates/api/deployment.yaml
+++ b/k8s/openstad/templates/api/deployment.yaml
@@ -226,7 +226,7 @@ spec:
       initContainers:
         - command: ["/bin/sh", "-c"]
           args:
-            - nc {{.Release.Name}}-mysql 3306 -z -w1 && node migrate.js;
+            - nc $API_DATABASE_HOST 3306 -z -w1 && node migrate.js;
           env:
             - name: DB_TYPE
               value: mysql


### PR DESCRIPTION
When using an external mysql database the netcat command fails because there is no mysql service inside the cluster. Because of that the initContainer fails.