### PR TITLE
add apos s3 env to frontend app

### DIFF
--- a/k8s/openstad/templates/frontend/deployment.yaml
+++ b/k8s/openstad/templates/frontend/deployment.yaml
@@ -82,6 +82,37 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.namespace
+
+            - name: APOS_S3_BUCKET
+              valueFrom:
+                secretKeyRef:
+                  key: bucket
+                  name: openstad-frontend-s3
+
+            - name: APOS_S3_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  key: endpoint
+                  name: openstad-frontend-s3
+
+            - name: APOS_S3_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: key
+                  name: openstad-frontend-s3
+
+            - name: APOS_S3_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: secret
+                  name: openstad-frontend-s3
+
+            - name: APOS_S3_REGION
+              valueFrom:
+                secretKeyRef:
+                  key: region
+                  name: openstad-frontend-s3
+
             - name: MY_POD_IP
               valueFrom:
                 fieldRef:
@@ -94,19 +125,23 @@ spec:
 
           resources:
 {{ toYaml .Values.frontend.resources | indent 12 }}
+{{- if (not .Values.frontend.S3.bucket) }}
           volumeMounts:
             - mountPath: /home/app/public/uploads
               name: data-uploads
+{{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       securityContext:
         fsGroup: 1000
         runAsGroup: 1000
         runAsUser: 1000
+{{- if (not .Values.frontend.S3.bucket) }}
       volumes:
         - name: data-uploads
           persistentVolumeClaim:
             claimName: frontend-uploads-claim
+{{- end }}
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/k8s/openstad/templates/persistence-claim.yml
+++ b/k8s/openstad/templates/persistence-claim.yml
@@ -1,20 +1,4 @@
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: frontend-data-claim
-  namespace: {{ .Release.Namespace }}
-  annotations: {{ .Values.persistence.annotations }}
-spec:
-{{- if ( and .Values.persistence .Values.persistence.storageClassName) }}
-  storageClassName: {{ .Values.persistence.storageClassName }}
-{{- end }}
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: {{ .Values.frontend.volumes.data.size }}
-
----
+{{- if (not .Values.frontend.S3.bucket) }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -30,7 +14,7 @@ spec:
   resources:
     requests:
       storage: {{ .Values.frontend.volumes.uploads.size }}
-
+{{- end }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/k8s/openstad/templates/secrets/frontend-s3.yaml
+++ b/k8s/openstad/templates/secrets/frontend-s3.yaml
@@ -1,0 +1,11 @@
+{{- if (.Values.frontend.S3.bucket) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openstad-frontend-s3
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/resource-policy": keep
+data:
+  {{ template "FrontendS3Secret" . }}
+{{- end }}

--- a/k8s/openstad/templates/template.yaml
+++ b/k8s/openstad/templates/template.yaml
@@ -63,6 +63,14 @@
   bucket:  {{ .Values.S3.bucket | default "openstad" | b64enc }}
 {{- end }}
 
+{{- define "FrontendS3Secret" -}}
+  endpoint: {{ .Values.frontend.S3.endpoint | default "" | b64enc }}
+  key: {{ .Values.frontend.S3.key | default "" | b64enc }}
+  secret: {{ .Values.frontend.S3.secret | default "" | b64enc }}
+  bucket: {{ .Values.frontend.S3.bucket | default "" | b64enc }}
+  region: {{ .Values.frontend.S3.region | default "" | b64enc }}
+{{- end }}
+
 {{- define "authCredSecret" -}}
   client_id: {{ .Values.secrets.database.auth.credentials.clientId | default "clientID" | b64enc }}
   client_secret: {{ .Values.secrets.database.auth.credentials.clientSecret | default ( randAlphaNum 12 | quote ) | b64enc }}

--- a/k8s/openstad/values.yaml
+++ b/k8s/openstad/values.yaml
@@ -132,6 +132,14 @@ frontend:
     # Docker image for this pod
     image: openstad/frontend:v0.14.1
 
+  # Optional to use an S3 for ApostropheCMS attachments.
+  S3:
+    endpoint:
+    key:
+    secret:
+    bucket:
+    region:
+
   # Subdomain for the service:
   # If filled it it will create a default url of: www.$subdomain.$baseurl
   # If not filled in the base will be used instead: www.$baseurl


### PR DESCRIPTION
Adding APOS_S3_* environment variables to the frontend application. 
- Add APOS_S3_* to values 
- Create S3 secret for frontend deployment 
- Prevent creating pvc when using s3 (if `frontend.S3.bucket` value is set)
- remove data pvc (not used) 