### PR TITLE
Update networking.k8s.io/v1beta1

### DIFF
--- a/docs/update_ingress.md
+++ b/docs/update_ingress.md
@@ -108,7 +108,7 @@ This can be done use a GET command on the namespace for the type Ingress.
 Using example below where we assume the application to be deployed in the openstad namespace:
 
 ```bash
-curl -H "Authorization: Bearer $TOKEN" -k https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_PORT_443_TCP_PORT/apis/networking.k8s.io/v1beta1/namespaces/openstad/ingresses
+curl -H "Authorization: Bearer $TOKEN" -k https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_PORT_443_TCP_PORT/apis/networking.k8s.io/v1/namespaces/openstad/ingresses
 ```
 
 This will return the following response starting with:
@@ -116,9 +116,9 @@ This will return the following response starting with:
 ```json
 {
   "kind": "IngressList",
-  "apiVersion": "networking.k8s.io/v1beta1",
+  "apiVersion": "networking.k8s.io/v1",
   "metadata": {
-    "selfLink": "/apis/networking.k8s.io/v1beta1/namespaces/openstad/ingresses",
+    "selfLink": "/apis/networking.k8s.io/v1/namespaces/openstad/ingresses",
     "resourceVersion": "1473825"
   },
   "items": [
@@ -126,7 +126,7 @@ This will return the following response starting with:
       "metadata": {
         "name": "openstad-api",
         "namespace": "openstad",
-        "selfLink": "/apis/networking.k8s.io/v1beta1/namespaces/openstad/ingresses/openstad-api",
+        "selfLink": "/apis/networking.k8s.io/v1/namespaces/openstad/ingresses/openstad-api",
         "uid": "7bc97ac8-fcb2-461d-9cab-d03dfc1d2fd7",
         "resourceVersion": "1375170",
         "generation": 1,
@@ -201,7 +201,7 @@ If you want to change for instance the hostname in the response about you do the
 ```bash
 curl -H "Authorization: Bearer $TOKEN" -XPOST -k \
      -d $INGRESS_OBJECT_FILE
-     https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_PORT_443_TCP_PORT/apis/networking.k8s.io/v1beta1/namespaces/openstad/ingresses/$INGRESS_OBJECT_NAME
+     https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_PORT_443_TCP_PORT/apis/networking.k8s.io/v1/namespaces/openstad/ingresses/$INGRESS_OBJECT_NAME
 ```
 
 #### 4.2 Patch
@@ -224,7 +224,7 @@ spec:
 ```bash
 curl -H "Authorization: Bearer $TOKEN" -XPATCH -k \
      -d $CHANGED_VALUES
-     https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_PORT_443_TCP_PORT/apis/networking.k8s.io/v1beta1/namespaces/openstad/ingresses/$INGRESS_OBJECT_NAME
+     https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_PORT_443_TCP_PORT/apis/networking.k8s.io/v1/namespaces/openstad/ingresses/$INGRESS_OBJECT_NAME
 ```
 
 ## Other usage
@@ -252,7 +252,7 @@ Creating a new Ingress would look like this:
             const k8sApi = kc.makeApiClient(k8s.NetworkingV1beta1Api)
 
             k8sApi.createNamespacedIngress(process.env.KUBERNETES_NAMESPACE, {
-              apiVersions: 'networking.k8s.io/v1beta1',
+              apiVersions: 'networking.k8s.io/v',
               kind: 'Ingress',
               metadata: {
                 name: `${unique-identifiers}`,

--- a/k8s/deployment/mailcatcher.yaml
+++ b/k8s/deployment/mailcatcher.yaml
@@ -51,7 +51,7 @@ spec:
       port: 1025
   type: ClusterIP
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: mailcatcher

--- a/k8s/openstad/templates/admin/ingress.yaml
+++ b/k8s/openstad/templates/admin/ingress.yaml
@@ -4,7 +4,7 @@
 {{ $servicePort := .Values.admin.service.httpPort }}
 {{ $tls := .Values.admin.ingress.tls }}
 
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 
 metadata:
@@ -31,16 +31,24 @@ spec:
     - host: {{ 1 }}
       http:
         paths:
-          - backend:
-              serviceName: {{ $serviceName }}
-              servicePort: {{ $servicePort }}
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $serviceName }}
+                port:
+                  number: {{ $servicePort }}
 {{- end }}
     - host: {{ template "openstad.admin.url" . }}
       http:
         paths:
-          - backend:
-              serviceName: {{ $serviceName }}
-              servicePort: {{ $servicePort }}
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $serviceName }}
+                port:
+                  number: {{ $servicePort }}
 
   tls:
     - secretName: {{ .Values.admin.ingress.tls.secretName }}

--- a/k8s/openstad/templates/adminer/ingress.yaml
+++ b/k8s/openstad/templates/adminer/ingress.yaml
@@ -4,7 +4,7 @@
 {{ $servicePort := .Values.adminer.service.httpPort }}
 {{ $tls := .Values.adminer.ingress.tls }}
 
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 
 metadata:
@@ -31,16 +31,24 @@ spec:
     - host: {{ 1 }}
       http:
         paths:
-          - backend:
-              serviceName: {{ $serviceName }}
-              servicePort: {{ $servicePort }}
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $serviceName }}
+                port:
+                  number: {{ $servicePort }}
 {{- end }}
     - host: {{ template "openstad.adminer.url" . }}
       http:
         paths:
-          - backend:
-              serviceName: {{ $serviceName }}
-              servicePort: {{ $servicePort }}
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $serviceName }}
+                port:
+                  number: {{ $servicePort }}
               
   tls:
     - secretName: {{ .Values.adminer.ingress.tls.secretName }}

--- a/k8s/openstad/templates/api/ingress.yaml
+++ b/k8s/openstad/templates/api/ingress.yaml
@@ -4,7 +4,7 @@
 {{ $servicePort := .Values.api.service.httpPort }}
 {{ $tls := .Values.api.ingress.tls }}
 
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 
 metadata:
@@ -31,16 +31,24 @@ spec:
     - host: {{ 1 }}
       http:
         paths:
-          - backend:
-              serviceName: {{ $serviceName }}
-              servicePort: {{ $servicePort }}
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $serviceName }}
+                port:
+                  number: {{ $servicePort }}
 {{- end }}
     - host: {{ template "openstad.api.url" . }}
       http:
         paths:
-          - backend:
-              serviceName: {{ $serviceName }}
-              servicePort: {{ $servicePort }}
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $serviceName }}
+                port:
+                  number: {{ $servicePort }}
 
   tls:
     - secretName: {{ .Values.api.ingress.tls.secretName }}

--- a/k8s/openstad/templates/auth/ingress.yaml
+++ b/k8s/openstad/templates/auth/ingress.yaml
@@ -4,7 +4,7 @@
 {{ $servicePort := .Values.auth.service.httpPort }}
 {{ $tls := .Values.auth.ingress.tls }}
 
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 
 metadata:
@@ -32,16 +32,24 @@ spec:
     - host: {{ 1 }}
       http:
         paths:
-          - backend:
-              serviceName: {{ $serviceName }}
-              servicePort: {{ $servicePort }}
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $serviceName }}
+                port:
+                  number: {{ $servicePort }}
 {{- end }}
     - host: {{ template "openstad.auth.url" . }}
       http:
         paths:
-          - backend:
-              serviceName: {{ $serviceName }}
-              servicePort: {{ $servicePort }}
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $serviceName }}
+                port:
+                  number: {{ $servicePort }}
 
   tls:
     - secretName: {{ .Values.auth.ingress.tls.secretName }}

--- a/k8s/openstad/templates/frontend/ingress.yaml
+++ b/k8s/openstad/templates/frontend/ingress.yaml
@@ -4,7 +4,7 @@
 {{ $servicePort := .Values.frontend.service.httpPort }}
 {{ $tls := .Values.frontend.ingress.tls }}
 
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 
 metadata:
@@ -31,17 +31,25 @@ spec:
     - host: {{ 1 }}
       http:
         paths:
-          - backend:
-              serviceName: {{ $serviceName }}
-              servicePort: {{ $servicePort }}
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $serviceName }}
+                port:
+                  number: {{ $servicePort }}
 {{- end }}
 
     - host: {{ template "openstad.frontend.urlwithoutWww" . }}
       http:
         paths:
-          - backend:
-              serviceName: {{ $serviceName }}
-              servicePort: {{ $servicePort }}
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $serviceName }}
+                port:
+                  number: {{ $servicePort }}
 
   tls:
     - secretName: {{ .Values.frontend.ingress.tls.secretName }}

--- a/k8s/openstad/templates/image/ingress.yaml
+++ b/k8s/openstad/templates/image/ingress.yaml
@@ -4,7 +4,7 @@
 {{ $servicePort := .Values.image.service.httpPort }}
 {{ $tls := .Values.image.ingress.tls }}
 
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 
 metadata:
@@ -31,16 +31,24 @@ spec:
     - host: {{ 1 }}
       http:
         paths:
-          - backend:
-              serviceName: {{ $serviceName }}
-              servicePort: {{ $servicePort }}
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $serviceName }}
+                port:
+                  number: {{ $servicePort }}
 {{- end }}
     - host: {{ template "openstad.image.url" . }}
       http:
         paths:
-          - backend:
-              serviceName: {{ $serviceName }}
-              servicePort: {{ $servicePort }}
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $serviceName }}
+                port:
+                  number: {{ $servicePort }}
 
   tls:
     - secretName: {{ .Values.image.ingress.tls.secretName }}


### PR DESCRIPTION
networking.k8s.io/v1beta1 is no longer supported, but networking.k8s.io/v1 requires a different syntax