### PR TITLE
Set MongoDB credentials for auth & frontend

### DIFF
--- a/k8s/openstad/Chart.yaml
+++ b/k8s/openstad/Chart.yaml
@@ -1,5 +1,6 @@
 apiVersion: v1
 name: openstad
 version: 0.2.1
-appVersion: 1.0
+appVersion: "1.0"
 description: This chart deploys the OpenStad Apostrophe project with optional databases.
+icon: https://openstad.org/uploads/attachments/ckf3z5imd3w4pnl3w91not6qs-favicon-2x.svg

--- a/k8s/openstad/requirements.yaml
+++ b/k8s/openstad/requirements.yaml
@@ -7,7 +7,7 @@ dependencies:
 
 - name: mongodb
   version: "7.14.5"
-  repository: "https://charts.bitnami.com/bitnami"
+  repository: "https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami"
   condition: dependencies.mongodb.enabled
   image:
     ## Bitnami MongoDB registry
@@ -23,5 +23,5 @@ dependencies:
 
 - name: mysql
   version: "6.14.2"
-  repository: "https://charts.bitnami.com/bitnami"
+  repository: "https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami"
   condition: dependencies.mysql.enabled

--- a/k8s/openstad/templates/_template.tpl
+++ b/k8s/openstad/templates/_template.tpl
@@ -18,6 +18,9 @@
   hostname: {{ .Values.secrets.mongodb.hostname | default (printf "%s-mongodb.%s.svc.cluster.local" .Release.Name .Release.Namespace) | b64enc }}
   hostport: {{ .Values.secrets.mongodb.hostport | default 27017 | toString | b64enc }}
   database: {{ .Values.secrets.mongodb.database | default "openstad_mongodb" | b64enc }}
+  user: {{ .Values.secrets.mongodb.user | default "" | b64enc }}
+  password: {{ .Values.secrets.mongodb.password | default "" | b64enc }}
+  auth-source: {{ .Values.secrets.mongodb.authSource | default "" | b64enc }}
 {{- end }}
 
 {{- define "cookieSecret" -}}

--- a/k8s/openstad/templates/adminer/ingress.yaml
+++ b/k8s/openstad/templates/adminer/ingress.yaml
@@ -1,5 +1,5 @@
----
 {{- if .Values.adminer.ingress.enabled -}}
+---
 {{ $serviceName := include "openstad.adminer.fullname" . }}
 {{ $servicePort := .Values.adminer.service.httpPort }}
 {{ $tls := .Values.adminer.ingress.tls }}
@@ -24,7 +24,7 @@ metadata:
 
   name: {{ template "openstad.adminer.fullname" . }}
   namespace: {{ .Release.Namespace }}
-  
+
 spec:
   rules:
 {{- range $host := .Values.adminer.ingress.hosts }}
@@ -41,7 +41,7 @@ spec:
           - backend:
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}
-              
+
   tls:
     - secretName: {{ .Values.adminer.ingress.tls.secretName }}
       hosts:

--- a/k8s/openstad/templates/auth/deployment.yaml
+++ b/k8s/openstad/templates/auth/deployment.yaml
@@ -80,6 +80,11 @@ spec:
               secretKeyRef:
                 name: openstad-db-credentials
                 key: hostport
+          - name: MONGO_DB_CONNECTION_STRING
+            valueFrom:
+              secretKeyRef:
+                key: auth-connection-string
+                name: openstad-secret
           - name: MONGO_DB_HOST
             valueFrom:
               secretKeyRef:

--- a/k8s/openstad/templates/auth/deployment.yaml
+++ b/k8s/openstad/templates/auth/deployment.yaml
@@ -85,6 +85,11 @@ spec:
               secretKeyRef:
                 key: hostname
                 name: openstad-mongo-credentials
+          - name: MONGO_DB_PORT
+            valueFrom:
+              secretKeyRef:
+                key: hostport
+                name: openstad-mongo-credentials
           - name: MONGO_DB_USER
             valueFrom:
               secretKeyRef:

--- a/k8s/openstad/templates/auth/deployment.yaml
+++ b/k8s/openstad/templates/auth/deployment.yaml
@@ -85,6 +85,21 @@ spec:
               secretKeyRef:
                 key: hostname
                 name: openstad-mongo-credentials
+          - name: MONGO_DB_USER
+            valueFrom:
+              secretKeyRef:
+                key: user
+                name: openstad-mongo-credentials
+          - name: MONGO_DB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: password
+                name: mongo-secret
+          - name: MONGO_DB_AUTHSOURCE
+            valueFrom:
+              secretKeyRef:
+                key: auth-source
+                name: openstad-mongo-credentials
           - name: DB_NAME
             valueFrom:
               secretKeyRef:

--- a/k8s/openstad/templates/auth/deployment.yaml
+++ b/k8s/openstad/templates/auth/deployment.yaml
@@ -84,7 +84,7 @@ spec:
             valueFrom:
               secretKeyRef:
                 key: auth-connection-string
-                name: openstad-secret
+                name: mongo-secret
           - name: MONGO_DB_HOST
             valueFrom:
               secretKeyRef:

--- a/k8s/openstad/templates/cert-manager/clusterissuer-prod.yaml
+++ b/k8s/openstad/templates/cert-manager/clusterissuer-prod.yaml
@@ -1,5 +1,5 @@
----
 {{- if .Values.clusterIssuer.enabled -}}
+---
 apiVersion: cert-manager.io/v1alpha3
 kind: ClusterIssuer
 metadata:

--- a/k8s/openstad/templates/cert-manager/clusterissuer-staging.yaml
+++ b/k8s/openstad/templates/cert-manager/clusterissuer-staging.yaml
@@ -1,5 +1,5 @@
----
 {{- if .Values.clusterIssuer.enabled -}}
+---
 apiVersion: cert-manager.io/v1alpha3
 kind: ClusterIssuer
 metadata:

--- a/k8s/openstad/templates/frontend/deployment.yaml
+++ b/k8s/openstad/templates/frontend/deployment.yaml
@@ -72,6 +72,11 @@ spec:
                 secretKeyRef:
                   key: hostname
                   name: openstad-mongo-credentials
+            - name: MONGO_DB_PORT
+              valueFrom:
+                secretKeyRef:
+                  key: hostport
+                  name: openstad-mongo-credentials
             - name: MONGO_DB_USER
               valueFrom:
                 secretKeyRef:

--- a/k8s/openstad/templates/frontend/deployment.yaml
+++ b/k8s/openstad/templates/frontend/deployment.yaml
@@ -62,6 +62,11 @@ spec:
                 secretKeyRef:
                   key: fixed_token
                   name: openstad-auth-credentials
+            - name: MONGO_DB_CONNECTION_STRING
+              valueFrom:
+                secretKeyRef:
+                  key: frontend-connection-string
+                  name: openstad-secret
             - name: MONGO_DB_HOST
               valueFrom:
                 secretKeyRef:

--- a/k8s/openstad/templates/frontend/deployment.yaml
+++ b/k8s/openstad/templates/frontend/deployment.yaml
@@ -66,7 +66,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   key: frontend-connection-string
-                  name: openstad-secret
+                  name: mongo-secret
             - name: MONGO_DB_HOST
               valueFrom:
                 secretKeyRef:

--- a/k8s/openstad/templates/frontend/deployment.yaml
+++ b/k8s/openstad/templates/frontend/deployment.yaml
@@ -72,6 +72,21 @@ spec:
                 secretKeyRef:
                   key: hostname
                   name: openstad-mongo-credentials
+            - name: MONGO_DB_USER
+              valueFrom:
+                secretKeyRef:
+                  key: user
+                  name: openstad-mongo-credentials
+            - name: MONGO_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: mongo-secret
+            - name: MONGO_DB_AUTHSOURCE
+              valueFrom:
+                secretKeyRef:
+                  key: auth-source
+                  name: openstad-mongo-credentials
             - name: DEFAULT_DB
               valueFrom:
                 secretKeyRef:

--- a/k8s/openstad/templates/secrets/mongo-secret.yaml
+++ b/k8s/openstad/templates/secrets/mongo-secret.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mongo-secret
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/resource-policy": keep
+data:
+  password: {{ .Values.secrets.mongodb.password | default "" | b64enc | quote }}

--- a/k8s/openstad/templates/secrets/mongo-secret.yaml
+++ b/k8s/openstad/templates/secrets/mongo-secret.yaml
@@ -8,3 +8,5 @@ metadata:
     "helm.sh/resource-policy": keep
 data:
   password: {{ .Values.secrets.mongodb.password | default "" | b64enc | quote }}
+  frontend-connection-string: {{ .Values.secrets.mongodb.frontendConnectionString | default "" | b64enc | quote }}
+  auth-connection-string: {{ .Values.secrets.mongodb.authConnectionString | default "" | replace "{database}" "sessions" | b64enc | quote }}

--- a/k8s/openstad/templates/secrets/mongo.yaml
+++ b/k8s/openstad/templates/secrets/mongo.yaml
@@ -10,4 +10,5 @@ data:
   hostname: {{ .Values.secrets.mongodb.hostname | default (printf "%s-mongodb.%s.svc.cluster.local" .Release.Name .Release.Namespace) | b64enc }}
   hostport: {{ .Values.secrets.mongodb.hostport | default 27017 | toString | b64enc }}
   database: {{ .Values.secrets.mongodb.database | default "openstad_mongodb" | b64enc }}
-
+  user: {{ .Values.secrets.mongodb.user | default "" | b64enc | quote }}
+  auth-source: {{ .Values.secrets.mongodb.authSource | default "" | b64enc | quote }}

--- a/k8s/openstad/values.yaml
+++ b/k8s/openstad/values.yaml
@@ -614,6 +614,8 @@ secrets:
     database:
     user:
     password:
+    # The authSource allows us to specify which database is associated with the given credentials.
+    # Reference: https://www.mongodb.com/docs/manual/reference/connection-string/#mongodb-urioption-urioption.authSource
     authSource:
   basicAuth:
     user:

--- a/k8s/openstad/values.yaml
+++ b/k8s/openstad/values.yaml
@@ -612,6 +612,9 @@ secrets:
     hostname:
     hostport:
     database:
+    user:
+    password:
+    authSource:
   basicAuth:
     user:
     password:

--- a/k8s/openstad/values.yaml
+++ b/k8s/openstad/values.yaml
@@ -614,9 +614,24 @@ secrets:
     database:
     user:
     password:
+
     # The authSource allows us to specify which database is associated with the given credentials.
     # Reference: https://www.mongodb.com/docs/manual/reference/connection-string/#mongodb-urioption-urioption.authSource
     authSource:
+
+    # The frontendConnectionString will take priority over the above MongoDB configuration for the frontend service
+    # Use {database} in this string to allow the application to specify the correct database
+    # Reference: https://www.mongodb.com/docs/manual/reference/connection-string/
+    # Example: "mongodb://mongoadmin:mongoadmin@localhost:27017/{database}?authSource=admin"
+    frontendConnectionString:
+
+    # The authConnectionString will take priority over the above MongoDB configuration for the auth service
+    # Keep in mind that the default database for the auth environment is `sessions`
+    # If this contains the `{database}` string, this will be replaced with `sessions` before being passed into the auth service
+    # Reference: https://www.mongodb.com/docs/manual/reference/connection-string/
+    # Example: "mongodb://mongoadmin:mongoadmin@localhost:27017/sessions?authSource=admin"
+    authConnectionString:
+
   basicAuth:
     user:
     password:


### PR DESCRIPTION
In https://github.com/openstad/openstad-frontend/pull/354 and https://github.com/openstad/openstad-oauth2-server/pull/112 new environment variables have been created to allow the auth & frontend services to connect to MongoDB with authentication.

This PR allows the k8s environment to make use of these new variables through secrets (fed by values).

There were a few small issues with linting that are also being resolved in this PR to allow for `helm lint` to pass succesfully.