### PR TITLE
Enable SSL connections to the MySQL server

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -44,7 +44,7 @@ secrets:
             -----END CERTIFICATE-----
 ```
 
-This certificate will be stored in the `openstad-db-credentials` secret, and used in the auth and api services to connect to the MySQL server through SSL.
+This certificate will be stored in the `openstad-db-credentials` secret, and used in the auth, api and image services to connect to the MySQL server through SSL.
 
 ## Existing LetsEncrypt
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -31,6 +31,21 @@ secrets:
     hostname: abcd
 ```
 
+## Using an SSL connection to your MySQL server
+
+By default the connection to the MySQL server does not use SSL. If you want to enforce this, you will have to provide a CA (Certificate Authority) certificate in the values:
+
+```yaml
+secrets:
+  database:
+    caCert: |-
+            -----BEGIN CERTIFICATE-----
+            .....
+            -----END CERTIFICATE-----
+```
+
+This certificate will be stored in the `openstad-db-credentials` secret, and used in the auth and api services to connect to the MySQL server through SSL.
+
 ## Existing LetsEncrypt
 
 In some cases LetsEncrypt is already available and configured on your cluster.

--- a/k8s/openstad/templates/_template.tpl
+++ b/k8s/openstad/templates/_template.tpl
@@ -8,6 +8,7 @@
   hostport: {{ .Values.secrets.database.hostport | default 3306 | toString | b64enc }}
   password: {{ .Values.mysql.db.password | default ( randAlphaNum 12 | quote ) | b64enc }}
   username: {{ .Values.secrets.database.username | default "openstad" | b64enc }}
+  ca-cert: {{ .Values.secrets.database.caCert | default "" | b64enc }}
 {{- end }}
 
 {{- define "sessionSecret" -}}

--- a/k8s/openstad/templates/adminer/ingress.yaml
+++ b/k8s/openstad/templates/adminer/ingress.yaml
@@ -1,4 +1,3 @@
----
 {{- if .Values.adminer.ingress.enabled -}}
 ---
 {{ $serviceName := include "openstad.adminer.fullname" . }}

--- a/k8s/openstad/templates/api/deployment.yaml
+++ b/k8s/openstad/templates/api/deployment.yaml
@@ -115,6 +115,11 @@ spec:
               secretKeyRef:
                 key: hostname
                 name: openstad-db-credentials
+          - name: MYSQL_CA_CERT
+            valueFrom:
+              secretKeyRef:
+                name: openstad-db-credentials
+                key: ca-cert
           - name: API_EMAILADDRESS
             value: {{ .Values.api.emailAddress }}
           - name: API_EXPRESS_PORT

--- a/k8s/openstad/templates/auth/deployment.yaml
+++ b/k8s/openstad/templates/auth/deployment.yaml
@@ -80,6 +80,11 @@ spec:
               secretKeyRef:
                 name: openstad-db-credentials
                 key: hostport
+          - name: MYSQL_CA_CERT
+            valueFrom:
+              secretKeyRef:
+                name: openstad-db-credentials
+                key: ca-cert
           - name: MONGO_DB_CONNECTION_STRING
             valueFrom:
               secretKeyRef:

--- a/k8s/openstad/templates/image/deployment.yaml
+++ b/k8s/openstad/templates/image/deployment.yaml
@@ -45,6 +45,11 @@ spec:
               secretKeyRef:
                 name: mysql-secret
                 key: mysql-password
+          - name: MYSQL_CA_CERT
+            valueFrom:
+              secretKeyRef:
+                name: openstad-db-credentials
+                key: ca-cert
           - name: APP_URL
             value: https://{{ template "openstad.image.url" . }}
           - name: FIRST_IMAGE_API_ACCESS_TOKEN

--- a/k8s/openstad/templates/secrets/database.yaml
+++ b/k8s/openstad/templates/secrets/database.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: openstad-db-credentials
-  namespace: {{ .Release.Namespace }} 
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/resource-policy": keep
     "helm.sh/hook": "pre-install"
@@ -14,3 +14,4 @@ data:
   hostname: {{ .Values.secrets.database.hostname | default (printf "%s-mysql.%s.svc.cluster.local" .Release.Name .Release.Namespace) | b64enc }}
   hostport: {{ .Values.secrets.database.hostport | default 3306 | toString | b64enc }}
   username: {{ .Values.secrets.database.username | default "openstad" | b64enc }}
+  ca-cert: {{ .Values.secrets.database.caCert | default "" | b64enc }}

--- a/k8s/openstad/values.yaml
+++ b/k8s/openstad/values.yaml
@@ -550,6 +550,13 @@ secrets:
     dbName:
     hostname:
     hostport:
+
+    # If you want to force an SSL connection to MySQL, provide a CA cert here
+    # This should be the content of the CA cert, including `-----BEGIN CERTIFICATE-----`
+    # Most cloud providers will provide this CA cert in their documentation;
+    # Amazon: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html
+    # Azure: https://docs.microsoft.com/en-us/azure/mysql/single-server/how-to-configure-ssl
+    # Google Cloud Platform: https://cloud.google.com/sql/docs/mysql/configure-ssl-instance
     caCert:
 
     ### Default db passwords for when you use the dependency

--- a/k8s/openstad/values.yaml
+++ b/k8s/openstad/values.yaml
@@ -550,6 +550,7 @@ secrets:
     dbName:
     hostname:
     hostport:
+    caCert:
 
     ### Default db passwords for when you use the dependency
     rootPassword:


### PR DESCRIPTION
By default the connection to the MySQL server is not going through SSL. To enable this we need to add a CA (Certificate Authority) certificate to the auth & api services.

Related PRs:
https://github.com/openstad/openstad-api/pull/241
https://github.com/openstad/openstad-oauth2-server/pull/113
https://github.com/openstad/openstad-image-server/pull/35