### PR TITLE
feat: allow user to add extra environment variables per service

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
           chmod a+x ./helm-release.sh
           ./helm-release.sh
         env:
-          CR_TOKEN: "${{ secrets.CR_TOKEN }}"
-          REPO_URL: "${{ secrets.REPO_URL }}"
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          REPO_URL: "${{ github.repositoryUrl }}"
           PAGES_BRANCH: master
-          OWNER: "${{ secrets.OWNER }}"
+          OWNER: "${{ github.repository_owner }}"

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -172,3 +172,9 @@ After running `helm upgrade`, the volume has the correct owner and can be writte
 ```
 
 The initContainer can now be removed from the deployment.yaml file.
+
+## Upgrading old/deprecated Kubernetes API's (UPGRADE FAILED issues)
+
+When trying to upgrade to a newer version of OpenStad you can run into issues where existing resources still use older and/or deprecated Kubernetes APIs. To migrate your Helm release you can use the [`mapkubeapis`](https://github.com/helm/helm-mapkubeapis) plugin. 
+
+More info about this issue can be found here: [Updating API Versions of a Release Manifest](https://helm.sh/docs/topics/kubernetes_apis/#updating-api-versions-of-a-release-manifest)

--- a/k8s/openstad/requirements.yaml
+++ b/k8s/openstad/requirements.yaml
@@ -25,3 +25,7 @@ dependencies:
   version: "6.14.2"
   repository: "https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami"
   condition: dependencies.mysql.enabled
+
+- name: common
+  version: "2.0.3"
+  repository: https://charts.bitnami.com/bitnami

--- a/k8s/openstad/templates/admin/deployment.yaml
+++ b/k8s/openstad/templates/admin/deployment.yaml
@@ -83,24 +83,12 @@ spec:
                 key: secret
                 name: openstad-session-secret
 
-          - name: MONGO_DB_HOST
-            valueFrom:
-                secretKeyRef:
-                  key: "hostname"
-                  name: openstad-mongo-credentials
-
           # KUBERNETES
           - name: SESSION_SECRET
             valueFrom:
               secretKeyRef:
                 key: secret
                 name: openstad-session-secret
-
-          - name: MONGO_DB_HOST
-            valueFrom:
-              secretKeyRef:
-                key: hostname
-                name: openstad-mongo-credentials
 
           - name: SITE_API_KEY
             valueFrom:
@@ -129,7 +117,11 @@ spec:
                 key: admin_client_secret
                 name: openstad-auth-credentials
 
-
+          - name: MONGO_DB_CONNECTION_STRING
+            valueFrom:
+              secretKeyRef:
+                key: admin-connection-string
+                name: mongo-secret
           - name: MONGO_DB_HOST
             valueFrom:
               secretKeyRef:
@@ -160,5 +152,9 @@ spec:
               secretKeyRef:
                 key: image_api_token
                 name: openstad-auth-credentials
+
+          {{- if .Values.admin.extraEnvVars }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.admin.extraEnvVars "context" $) | nindent 10 }}
+          {{- end }}
         resources:
 {{ toYaml .Values.admin.resources | indent 12 }}

--- a/k8s/openstad/templates/api/deployment.yaml
+++ b/k8s/openstad/templates/api/deployment.yaml
@@ -206,6 +206,9 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: status.podIP
+          {{- if .Values.api.extraEnvVars }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.api.extraEnvVars "context" $) | nindent 10 }}
+          {{- end }}
           image: {{ .Values.api.deploymentContainer.image }}
           imagePullPolicy: Always
           name: {{ template "openstad.api.fullname" . }}
@@ -276,11 +279,6 @@ spec:
                 secretKeyRef:
                   key: client_secret
                   name: openstad-auth-credentials
-
-            {{- if .Values.api.extraEnvVars }}
-            {{- include "common.tplvalues.render" (dict "value" .Values.api.extraEnvVars "context" $) | nindent 10 }}
-            {{- end }}
-
           image: {{ .Values.api.deploymentContainer.image }}
           imagePullPolicy: Always
           name: init-db-ready

--- a/k8s/openstad/templates/api/deployment.yaml
+++ b/k8s/openstad/templates/api/deployment.yaml
@@ -277,6 +277,10 @@ spec:
                   key: client_secret
                   name: openstad-auth-credentials
 
+            {{- if .Values.api.extraEnvVars }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.api.extraEnvVars "context" $) | nindent 10 }}
+            {{- end }}
+
           image: {{ .Values.api.deploymentContainer.image }}
           imagePullPolicy: Always
           name: init-db-ready

--- a/k8s/openstad/templates/auth/deployment.yaml
+++ b/k8s/openstad/templates/auth/deployment.yaml
@@ -197,6 +197,10 @@ spec:
               fieldRef:
                 fieldPath: status.podIP
 
+          {{- if .Values.auth.extraEnvVars }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.auth.extraEnvVars "context" $) | nindent 10 }}
+          {{- end }}
+
         resources:
 {{ toYaml .Values.auth.resources | indent 12 }}
         readinessProbe:

--- a/k8s/openstad/templates/auth/deployment.yaml
+++ b/k8s/openstad/templates/auth/deployment.yaml
@@ -243,6 +243,9 @@ spec:
               name: mysql-secret
               key: mysql-password
         - name: DB_NAME
-          value: auth
+          valueFrom:
+              secretKeyRef:
+                name: openstad-auth-db
+                key: database
         command: ["/bin/sh","-c"]
         args: ['knex migrate:latest']

--- a/k8s/openstad/templates/frontend/deployment.yaml
+++ b/k8s/openstad/templates/frontend/deployment.yaml
@@ -112,6 +112,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.namespace
 
+            {{- if (.Values.frontend.S3.bucket) }}
             - name: APOS_S3_BUCKET
               valueFrom:
                 secretKeyRef:
@@ -141,6 +142,7 @@ spec:
                 secretKeyRef:
                   key: region
                   name: openstad-frontend-s3
+            {{- end }}
 
             - name: MY_POD_IP
               valueFrom:
@@ -151,6 +153,10 @@ spec:
             - name: NODE_TLS_REJECT_UNAUTHORIZED
               value: "0"
 {{- end }}
+
+            {{- if .Values.frontend.extraEnvVars }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.frontend.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
 
           resources:
 {{ toYaml .Values.frontend.resources | indent 12 }}

--- a/k8s/openstad/templates/image/deployment.yaml
+++ b/k8s/openstad/templates/image/deployment.yaml
@@ -66,6 +66,11 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
+
+          {{- if .Values.image.extraEnvVars }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.image.extraEnvVars "context" $) | nindent 10 }}
+          {{- end }}
+
         resources:
 {{ toYaml .Values.image.resources | indent 12 }}
         readinessProbe:

--- a/k8s/openstad/templates/secrets/frontend-s3.yaml
+++ b/k8s/openstad/templates/secrets/frontend-s3.yaml
@@ -1,3 +1,4 @@
+---
 {{- if (.Values.frontend.S3.bucket) }}
 apiVersion: v1
 kind: Secret

--- a/k8s/openstad/templates/secrets/mongo-secret.yaml
+++ b/k8s/openstad/templates/secrets/mongo-secret.yaml
@@ -10,3 +10,4 @@ data:
   password: {{ .Values.secrets.mongodb.password | default "" | b64enc | quote }}
   frontend-connection-string: {{ .Values.secrets.mongodb.frontendConnectionString | default "" | b64enc | quote }}
   auth-connection-string: {{ .Values.secrets.mongodb.authConnectionString | default "" | replace "{database}" "sessions" | b64enc | quote }}
+  admin-connection-string: {{ .Values.secrets.mongodb.adminConnectionString | default "" | b64enc | quote }}

--- a/k8s/openstad/values.yaml
+++ b/k8s/openstad/values.yaml
@@ -168,6 +168,9 @@ frontend:
       secretName: openstad-tls-frontend
       hosts: []
 
+  # Inject extra environment variables
+  extraEnvVars: []
+
   # Resources:
   resources:
     # Max resources
@@ -312,6 +315,9 @@ auth:
       secretName: openstad-tls-auth
       hosts: []
 
+  # Inject extra environment variables
+  extraEnvVars: []
+
   # Resources:
   resources:
     # Max resources
@@ -379,6 +385,9 @@ admin:
     tls:
       secretName: openstad-tls-admin
       hosts: []
+
+  # Inject extra environment variables
+  extraEnvVars: []
 
   # Resources:
   resources:
@@ -452,6 +461,9 @@ api:
       secretName: openstad-tls-api
       hosts: []
 
+  # Inject extra environment variables
+  extraEnvVars: []
+
   # Resources:
   resources:
     # Max resources
@@ -515,6 +527,9 @@ image:
     tls:
         secretName: openstad-tls-image
         hosts: []
+
+  # Inject extra environment variables
+  extraEnvVars: []
 
   # Resources:
   resources:
@@ -647,6 +662,12 @@ secrets:
     # Reference: https://www.mongodb.com/docs/manual/reference/connection-string/
     # Example: "mongodb://mongoadmin:mongoadmin@localhost:27017/sessions?authSource=admin"
     authConnectionString:
+
+    # The adminConnectionString will take priority over the above MongoDB configuration for the admin service
+    # Use {database} in this string to allow the application to specify the correct database
+    # Reference: https://www.mongodb.com/docs/manual/reference/connection-string/
+    # Example: "mongodb://mongoadmin:mongoadmin@localhost:27017/{database}?authSource=admin"
+    adminConnectionString:
 
   basicAuth:
     user:


### PR DESCRIPTION
This allows users to set extra environment variables through the `values.yml` file. We use some extra environment variables for our installation of the OpenStad Amsterdam cluster. With this changes we no longer have to change the helm templates and can specify other values per environment.

Tested with k8s 1.22 and k8s 1.25