### PR TITLE
fix: allow to override `FROM_NAME` and `FROM_EMAIL` env variable

### DIFF
--- a/k8s/openstad/templates/auth/deployment.yaml
+++ b/k8s/openstad/templates/auth/deployment.yaml
@@ -147,7 +147,10 @@ spec:
             value: https://{{ template "openstad.admin.url" . }}
 
           - name: FROM_NAME
-            value: "Openstad api"
+            value: {{ default .Values.auth.fromName "Openstad api" }}
+
+          - name: FROM_EMAIL
+            value: {{ or .Values.auth.fromEmail .Values.secrets.mail.auth.user }}
 
           - name: AUTH_FIRST_CLIENT_LOGIN_CODE
             valueFrom:
@@ -178,9 +181,6 @@ spec:
               secretKeyRef:
                 key: admin_client_secret
                 name: openstad-auth-credentials
-
-          - name: FROM_EMAIL
-            value: {{ .Values.secrets.mail.auth.user }}
 
           - name: DEFAULT_FAVICON
             value: {{ .Values.auth.defaultFavicon }}

--- a/k8s/openstad/values.yaml
+++ b/k8s/openstad/values.yaml
@@ -339,6 +339,8 @@ auth:
 
   defaultFavicon:
 
+  fromName:
+  fromEmail:
 
 ## Settings for the Admin server
 admin:


### PR DESCRIPTION
This can be an issue when using sendgrid SMTP server where the user name is `apikey`. This is not a valid email address and when the auth service sends an email it will not be sent by Sendgrid (since the from email = `apikey`). 

This is an issue for auth clients that don't have a `fromEmail` defined in there config.