### PR TITLE
fix: MongoDB connection string contained invalid tokens

### DIFF
--- a/k8s/openstad/templates/secrets/mongo-secret.yaml
+++ b/k8s/openstad/templates/secrets/mongo-secret.yaml
@@ -9,5 +9,5 @@ metadata:
 data:
   password: {{ .Values.secrets.mongodb.password | default "" | b64enc | quote }}
   frontend-connection-string: {{ .Values.secrets.mongodb.frontendConnectionString | default "" | b64enc | quote }}
-  auth-connection-string: {{ .Values.secrets.mongodb.authConnectionString | default "" | replace "{database}" "sessions" | b64enc | quote }}
+  auth-connection-string: {{ .Values.secrets.mongodb.authConnectionString | default "" | b64enc | quote }}
   admin-connection-string: {{ .Values.secrets.mongodb.adminConnectionString | default "" | b64enc | quote }}


### PR DESCRIPTION
The `authConnectionString` was allowed to contain `{database}` as a variable which would be replaced with the correct database. However, Jekyll (which is powering the chart-releaser w/ Github pages) does not work correctly with curly braces within these YAML templates.

This is fixed by replacing this variable within the oAuth service itself.