### PR TITLE
Remove duplicate wildcardhost and frontend with subdomains

### DIFF
--- a/k8s/openstad/templates/admin/deployment.yaml
+++ b/k8s/openstad/templates/admin/deployment.yaml
@@ -56,13 +56,10 @@ spec:
             value: "no"
 
           - name: FRONTEND_URL
-            value: https://{{ .Values.host.base }}
+            value: https://{{ template "openstad.frontend.url" . }}
 
           - name: PUBLIC_IP
             value: {{ .Values.host.publicIp }}
-
-          - name: WILDCARD_HOST
-            value: {{ .Values.host.base }}
 
           - name: KUBERNETES_CLUSTER_ISSUER
             value: '{{ template "openstad.clusterIssuer.name" . }}'


### PR DESCRIPTION
This removes the duplicate `WILDCARD_HOST` env variable that wasn't configurable through values.

This also fixes an issue where the admin service didn't get a correct frontend url when using a subdomain for the frontend (like: cms.openstad.org).