### PR TITLE
Pass MongoDB user/pass/authsource to Admin deployment

### DIFF
--- a/k8s/openstad/templates/admin/deployment.yaml
+++ b/k8s/openstad/templates/admin/deployment.yaml
@@ -130,6 +130,22 @@ spec:
                 key: hostport
                 name: openstad-mongo-credentials
 
+          - name: MONGO_DB_USER
+            valueFrom:
+              secretKeyRef:
+                key: user
+                name: openstad-mongo-credentials
+          - name: MONGO_DB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: password
+                name: mongo-secret
+          - name: MONGO_DB_AUTHSOURCE
+            valueFrom:
+              secretKeyRef:
+                key: auth-source
+                name: openstad-mongo-credentials
+
           - name: MY_POD_IP
             valueFrom:
               fieldRef:


### PR DESCRIPTION
Adding `MONGO_DB_USER`, `MONGO_DB_PASSWORD` and `MONGO_DB_AUTHSOURCE` to be in line with the frontend deployment. `MONGO_DB_CONNECTION_STRING` will still take precedence over these new env vars in the admin pod — just like the frontend. But this will still allow users to use User/pass/authsource to authenticate with MongoDB.