### PR TITLE
feat(api): add `MAX_POOL_SIZE` env variable to configure maxPoolSize

### DIFF
--- a/k8s/openstad/Chart.yaml
+++ b/k8s/openstad/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: openstad
-version: 1.0.4
+version: 1.0.5
 appVersion: "1.0"
 description: This chart deploys the OpenStad Apostrophe project with optional databases.
 icon: https://openstad.org/uploads/attachments/ckf3z5imd3w4pnl3w91not6qs-favicon-2x.svg

--- a/k8s/openstad/templates/api/deployment.yaml
+++ b/k8s/openstad/templates/api/deployment.yaml
@@ -115,6 +115,11 @@ spec:
               secretKeyRef:
                 key: hostname
                 name: openstad-db-credentials
+          - name: MAX_POOL_SIZE
+            valueFrom:
+              secretKeyRef:
+                key: maxPoolSize
+                name: openstad-db-credentials
           - name: MYSQL_CA_CERT
             valueFrom:
               secretKeyRef:

--- a/k8s/openstad/values.yaml
+++ b/k8s/openstad/values.yaml
@@ -580,6 +580,7 @@ secrets:
     dbName:
     hostname:
     hostport:
+    maxPoolSize: 5
 
     # If you want to force an SSL connection to MySQL, provide a CA cert here
     # This should be the content of the CA cert, including `-----BEGIN CERTIFICATE-----`

--- a/k8s/openstad/values.yaml
+++ b/k8s/openstad/values.yaml
@@ -580,6 +580,7 @@ secrets:
     dbName:
     hostname:
     hostport:
+    # Max connections used in connection pool
     maxPoolSize: 5
 
     # If you want to force an SSL connection to MySQL, provide a CA cert here


### PR DESCRIPTION
Adds `MAX_POOL_SIZE` env variable to configure maxPoolSize of database connection, used to be hardcoded to 5 which with high traffic sites would drain the pool to quickly.
