### PR TITLE
fix: set correct apiVersion for cronjobs

### DIFF
--- a/k8s/openstad/templates/api/cronjob-mongodb.yaml
+++ b/k8s/openstad/templates/api/cronjob-mongodb.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.k8sCronjobs.mongodb.enabled -}}
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ template "openstad.api.fullname" . }}-cronjob-mongodb

--- a/k8s/openstad/templates/api/cronjob-mysql.yaml
+++ b/k8s/openstad/templates/api/cronjob-mysql.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.k8sCronjobs.mysql.enabled -}}
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ template "openstad.api.fullname" . }}-cronjob-mysql


### PR DESCRIPTION
`batch/v1beta1` is deprecated, so moving them to `batch/v1`