### PR TITLE
fix: add `maxPoolSize` to openstad-db-credentials secret

### DIFF
--- a/k8s/openstad/templates/secrets/database.yaml
+++ b/k8s/openstad/templates/secrets/database.yaml
@@ -15,3 +15,4 @@ data:
   hostport: {{ .Values.secrets.database.hostport | default 3306 | toString | b64enc }}
   username: {{ .Values.secrets.database.username | default "openstad" | b64enc }}
   ca-cert: {{ .Values.secrets.database.caCert | default "" | b64enc }}
+  maxPoolSize: {{ .Values.secrets.database.maxPoolSize | default "" | b64enc }}

--- a/k8s/secret/database.yml
+++ b/k8s/secret/database.yml
@@ -10,3 +10,5 @@ data:
   hostport: BASE64ENCODED=
   password: BASE64ENCODED=
   username: BASE64ENCODED=
+  ca-cert: BASE64ENCODED=
+  maxPoolSize: BASE64ENCODED=


### PR DESCRIPTION
This will add `maxPoolSize` to `openstad-db-credentials`. Without this key MongoDB will throw errors when starting.

Also adds `ca-cert` and `maxPoolSize` to default secret.